### PR TITLE
fix memory overflow in windows

### DIFF
--- a/public/hash.js
+++ b/public/hash.js
@@ -9,8 +9,8 @@ self.onmessage = e => {
   const spark = new self.SparkMD5.ArrayBuffer();
   let percentage = 0;
   let count = 0;
+  const reader = new FileReader();
   const loadNext = index => {
-    const reader = new FileReader();
     reader.readAsArrayBuffer(fileChunkList[index].file);
     reader.onload = e => {
       count++;


### PR DESCRIPTION
Hello, I found the chrome in windows crashed when calc the hash.The error msg is "SBOX_FATAL_MEMORY_EXCEEDED", most likely memory overflow the browser sandbox.

The problem is probably the `FileRender` is created multi times, and the file content cannot be free.So, I move the line13 to line12.It seems can solve the problem.